### PR TITLE
fix: update installation instructions and clarify Expo documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,19 +99,31 @@ Built by a developer who've shipped apps to millions of users. Every edge case h
 
 ## 🚀 Installation
 
+> **⚠️ Important**: RN-Tosty uses **native modules** and requires additional setup steps. **Don't just install and expect it to work!**
+>
+> **📖 [Complete Installation Guide](https://codestz.github.io/rn-tosty/docs/getting-started/installation)** ← **Follow this for proper setup**
+
+### Quick Install (Setup Required)
+
 ```bash
+# Step 1: Install the package
 npm install rn-tosty
 # or
 yarn add rn-tosty
-```
 
-### Required Dependencies
-
-```bash
+# Step 2: Install required native dependencies
 npm install react-native-reanimated react-native-safe-area-context react-native-device-info react-native-svg
 ```
 
-> **Note**: `react-native-safe-area-context` is a peer dependency to avoid conflicts with apps that already use it.
+### ⚡ What's Next?
+
+After installing, you **MUST** complete the setup:
+
+- **React Native CLI**: [Platform-specific setup](https://codestz.github.io/rn-tosty/docs/getting-started/installation#-react-native-cli-installation) (iOS/Android configuration)
+- **Expo Projects**: [Special Expo setup](https://codestz.github.io/rn-tosty/docs/getting-started/installation#-expo-installation) (Cannot use Expo Go!)
+- **Configuration**: Babel config for Reanimated, pod install for iOS, etc.
+
+> **🚨 Expo Users**: This library **cannot run in Expo Go**. You need **Expo Development Build** or **EAS Build**.
 
 ## 🎯 Quick Start
 

--- a/docs/docs/getting-started/installation.md
+++ b/docs/docs/getting-started/installation.md
@@ -2,6 +2,10 @@
 
 Get RN-Tosty up and running in your React Native app in just a few minutes.
 
+:::warning Native Modules Required
+**RN-Tosty uses native modules** and requires native dependencies. This means it cannot be used in Expo Go but works with **Expo Development Builds**, **EAS Build**, or **ejected Expo projects**.
+:::
+
 ## 📋 Requirements
 
 Before installing RN-Tosty, make sure your project meets these requirements:
@@ -10,6 +14,7 @@ Before installing RN-Tosty, make sure your project meets these requirements:
 - **React**: ^18.0.0 or ^19.0.0
 - **iOS**: 11.0+
 - **Android**: API level 21+
+- **Expo**: SDK 49+ (requires Development Build or EAS Build)
 
 ## 🚀 Quick Install
 
@@ -48,6 +53,100 @@ pnpm add react-native-reanimated react-native-safe-area-context react-native-dev
 - **react-native-device-info**: Automatic device detection and adaptation
 - **react-native-svg**: Beautiful vector icons that scale perfectly
   :::
+
+## 📱 Expo Installation
+
+Since RN-Tosty uses native modules, you cannot use it with **Expo Go**. However, it works perfectly with:
+
+### Option 1: Expo Development Build (Recommended)
+
+1. **Install RN-Tosty and dependencies**:
+
+   ```bash
+   npx expo install rn-tosty react-native-reanimated react-native-safe-area-context react-native-device-info react-native-svg
+   ```
+
+2. **Configure Reanimated** in your `babel.config.js`:
+
+   ```js
+   module.exports = function (api) {
+     api.cache(true);
+     return {
+       presets: ['babel-preset-expo'],
+       plugins: [
+         'react-native-reanimated/plugin', // This must be last
+       ],
+     };
+   };
+   ```
+
+3. **Create a development build**:
+
+   ```bash
+   # Install EAS CLI if you haven't
+   npm install -g @expo/cli
+
+   # Create development build
+   npx expo run:ios
+   # or
+   npx expo run:android
+   ```
+
+### Option 2: EAS Build
+
+1. **Install dependencies**:
+
+   ```bash
+   npx expo install rn-tosty react-native-reanimated react-native-safe-area-context react-native-device-info react-native-svg
+   ```
+
+2. **Configure Reanimated** in your `babel.config.js` (same as above)
+
+3. **Build with EAS**:
+
+   ```bash
+   # Install EAS CLI
+   npm install -g eas-cli
+
+   # Configure EAS
+   eas build:configure
+
+   # Build for development
+   eas build --profile development
+   ```
+
+### Option 3: Ejected Expo Project
+
+If you've ejected your Expo project, follow the standard React Native installation instructions below.
+
+### 🔧 Expo Troubleshooting
+
+#### "Cannot resolve module" in Expo
+
+```bash
+# Clear Expo cache
+npx expo start -c
+
+# Or restart with clean Metro cache
+npx expo r -c
+```
+
+#### EAS Build fails
+
+Make sure your `eas.json` includes the required native dependencies:
+
+```json
+{
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal"
+    }
+  }
+}
+```
+
+## 🚀 React Native CLI Installation
 
 ### 3. Platform-Specific Setup
 
@@ -214,6 +313,40 @@ npx react-native run-android
 
 2. Check that MainApplication.java includes the Reanimated package
 
+#### Expo-Specific Issues
+
+#### "RN-Tosty doesn't work in Expo Go"
+
+This is expected behavior. RN-Tosty uses native modules and cannot run in Expo Go. You need to:
+
+1. **Use Expo Development Build**: `npx expo run:ios` or `npx expo run:android`
+2. **Use EAS Build**: Build a custom development client
+3. **Eject from Expo**: Convert to a bare React Native project
+
+#### "Reanimated not working in Expo"
+
+Make sure your `babel.config.js` is properly configured:
+
+```js
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: [
+      'react-native-reanimated/plugin', // Must be last!
+    ],
+  };
+};
+```
+
+Then rebuild your development build:
+
+```bash
+npx expo run:ios --clear-cache
+# or
+npx expo run:android --clear-cache
+```
+
 ### Version Compatibility
 
 | RN-Tosty Version | React Native | React   | Reanimated |
@@ -232,7 +365,8 @@ npx react-native run-android
 ### 🔄 Tested Configurations
 
 - **React Native**: 0.70.x, 0.71.x, 0.72.x, 0.73.x, 0.74.x
-- **Expo**: SDK 49+
+- **Expo**: SDK 49+ (Development Build / EAS Build only)
+- **Expo Go**: ❌ Not supported (native modules required)
 - **New Architecture**: Partial support (Fabric + TurboModules)
 
 ## 🎯 Next Steps

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -1731,30 +1731,6 @@ PODS:
     - React-utils (= 0.79.2)
   - RNDeviceInfo (14.0.4):
     - React-Core
-  - RNGestureHandler (2.26.0):
-    - DoubleConversion
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-hermes
-    - React-ImageManager
-    - React-jsi
-    - React-NativeModulesApple
-    - React-RCTFabric
-    - React-renderercss
-    - React-rendererdebug
-    - React-utils
-    - ReactCodegen
-    - ReactCommon/turbomodule/bridging
-    - ReactCommon/turbomodule/core
-    - Yoga
   - RNReanimated (3.18.0):
     - DoubleConversion
     - glog
@@ -1979,7 +1955,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - RnTosty (0.1.0):
+  - RnTosty (1.0.1):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2080,7 +2056,6 @@ DEPENDENCIES:
   - ReactCodegen (from `build/generated/ios`)
   - ReactCommon/turbomodule/core (from `../node_modules/react-native/ReactCommon`)
   - RNDeviceInfo (from `../node_modules/react-native-device-info`)
-  - RNGestureHandler (from `../node_modules/react-native-gesture-handler`)
   - RNReanimated (from `../node_modules/react-native-reanimated`)
   - RNScreens (from `../node_modules/react-native-screens`)
   - RNSVG (from `../node_modules/react-native-svg`)
@@ -2235,8 +2210,6 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon"
   RNDeviceInfo:
     :path: "../node_modules/react-native-device-info"
-  RNGestureHandler:
-    :path: "../node_modules/react-native-gesture-handler"
   RNReanimated:
     :path: "../node_modules/react-native-reanimated"
   RNScreens:
@@ -2320,14 +2293,13 @@ SPEC CHECKSUMS:
   ReactCodegen: c63eda03ba1d94353fb97b031fc84f75a0d125ba
   ReactCommon: 76d2dc87136d0a667678668b86f0fca0c16fdeb0
   RNDeviceInfo: d863506092aef7e7af3a1c350c913d867d795047
-  RNGestureHandler: c7986dd1eb909e329882af067c05db0702a659b3
   RNReanimated: 722d67dfde539bfe29b572878f4bc805f727726b
   RNScreens: 482e9707f9826230810c92e765751af53826d509
   RNSVG: 8a1054afe490b5d63b9792d7ae3c1fde8c05cdd0
-  RnTosty: d3dd4973789a5e800b4ceb58203a9c2c2856804b
+  RnTosty: cfaca3ce53ec357cab2968bfc2f977b221d86226
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: c758bfb934100bb4bf9cbaccb52557cee35e8bdf
 
 PODFILE CHECKSUM: df954752d4de633b4a6ccb76c2f8f3e23ad23d51
 
-COCOAPODS: 1.15.2
+COCOAPODS: 1.16.2


### PR DESCRIPTION
- Clarify how to integrate rn-tosty into a expo project.

- Update Readme to clear indicate to follow the documentation site.